### PR TITLE
Bump codepagex from 0.1.4 to 0.1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: elixir
 elixir:
-- 1.4
 - 1.5
 - 1.6
 - 1.7

--- a/build/19/Dockerfile
+++ b/build/19/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=en_US.UTF-8
 RUN yum install -y https://yum.kaos.st/kaos-repo-latest.el6.noarch.rpm
 RUN yum install -y unzip git erlang19
 
-RUN curl -fSL -o elixir-precompiled.zip https://github.com/elixir-lang/elixir/releases/download/v1.4.5/Precompiled.zip
+RUN curl -fSL -o elixir-precompiled.zip https://github.com/elixir-lang/elixir/releases/download/v1.5.1/Precompiled.zip
 
 RUN unzip -d /usr/local elixir-precompiled.zip
 RUN mix local.hex --force

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Smppsend.Mixfile do
       {:dye, "~> 0.4.0"},
       {:coverex, "~> 1.4.1", only: :test},
       {:doppler, "~> 0.1.0", only: :test},
-      {:codepagex, "~> 0.1.4"}
+      {:codepagex, "~> 0.1.6"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Smppsend.Mixfile do
     [
       app: :smppsend,
       version: "0.1.16",
-      elixir: "~> 1.1",
+      elixir: "~> 1.5",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "agent": {:hex, :agent, "0.1.0", "463819be23aac571c45579d5ef7dd2155803ed885cd95e66f9550216847b96e9", [:rebar3], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
-  "codepagex": {:hex, :codepagex, "0.1.4", "dae3bc57e9334c324914b32ed61c0a30929fac3e73dc71fc611ed7eeb2dcb867", [:mix], [], "hexpm"},
+  "codepagex": {:hex, :codepagex, "0.1.6", "49110d09a25ee336a983281a48ef883da4c6190481e0b063afe2db481af6117e", [:mix], [], "hexpm"},
   "coverex": {:hex, :coverex, "1.4.15", "60fadf825a6c0439b79d1f98cdb54b6733cdd5cb1b35d15d56026c44ed15a5a8", [:mix], [{:hackney, "~> 1.5", [hex: :hackney, repo: "hexpm", optional: false]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "doppler": {:hex, :doppler, "0.1.0", "398461a44b5d459df7b8c7c2fd72fc7e00f5a15cbacf7575593a61ef28f92d88", [:rebar3], [{:agent, "~> 0.1.0", [hex: :agent, repo: "hexpm", optional: false]}], "hexpm"},
   "dye": {:hex, :dye, "0.4.1", "e8d4b548fd17b441ebaaa53c823c29026bd17704bc9057304f15befb7e180df3", [:mix], [], "hexpm"},


### PR DESCRIPTION
This is to [fix](https://github.com/tallakt/codepagex/pull/22) an argument error when compiling:

```elixir
== Compilation error in file lib/codepagex.ex ==
** (ArgumentError) expected a keyword list, but an entry in the list is not a two-element tuple with an atom as its first element, got: {"ETSI/GSM0338", "<redacted>/smppsend/deps/codepagex/lib/codepagex/../../unicode/ETSI/GSM0338.TXT"}
    (elixir 1.12.2) lib/keyword.ex:475: Keyword.keys/1
    lib/codepagex/mappings.ex:179: Codepagex.Mappings.encoding_list/1
    lib/codepagex/mappings.ex:135: anonymous fn/1 in Codepagex.Mappings.aliases/1
    (elixir 1.12.2) lib/enum.ex:1067: anonymous fn/3 in Enum.filter/2
    (stdlib 3.15.1) maps.erl:410: :maps.fold_1/3
    (elixir 1.12.2) lib/enum.ex:2397: Enum.filter/2
    lib/codepagex/mappings.ex:134: Codepagex.Mappings.aliases/1
    lib/codepagex.ex:294: (module)
```

This, however [raises the required Elixir version to 1.5](https://github.com/tallakt/codepagex/commit/f9d19f4d4ce75bb7dae6136084e766875e685509)